### PR TITLE
Fix bug where getPublicKey was not called

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ export default function fastifyJwtSecret(options) {
         return onError(err, newError => cb(newError, null));
       }
       // Provide the key.
-      return cb(null, key.getPublicKey);
+      return cb(null, key.getPublicKey());
     });
   };
 }


### PR DESCRIPTION
We noticed that when using `fastify-authz-jwks@v1.1.12` (see #2), we were getting timeouts on all our fastify API calls. Seems like updating `node-jwks-rsa@v2.x` did not like it when `getPublicKey` was not called but only referenced in the callback. `fastify-jwt` which `node-jwks-rsa` uses under the hood expects either a string or a function with a callback, and by not calling `getPublicKey` you were not conforming to either of those conditions.

If we call this, it immediately fixed the issue of API calls passing through this middleware timing out.

I would be surprised if the latest version of `fastify-authz-jwks` would work for anyone else.